### PR TITLE
UPDATED `Fundamental_of_JS.md` #9 Edited `#### Distinction between String Primitives and 'String' Objects`

### DIFF
--- a/NEW/IN-DEPTH/Fundamental_of_JS.md
+++ b/NEW/IN-DEPTH/Fundamental_of_JS.md
@@ -4195,7 +4195,7 @@ A similar result can be achieved using the `localeCompare()` method inherited by
 
 
  String primitives and `String` objects also give different results when using `eval()`.
- 
+ Primitives passed to `eval` are treated as source code;
  
  
 #### Template Literals


### PR DESCRIPTION
UPDATED `Fundamental_of_JS.md` #9

Edited `#### Distinction between String Primitives and 'String' Objects`
in `### String` in `## Standard built-in objects`
+- Added description