### PR TITLE
UPDATED `Fundamental_of_JS.md` #10 Edited `#### Distinction between String Primitives and 'String' Objects`

### DIFF
--- a/NEW/IN-DEPTH/Fundamental_of_JS.md
+++ b/NEW/IN-DEPTH/Fundamental_of_JS.md
@@ -4196,6 +4196,8 @@ A similar result can be achieved using the `localeCompare()` method inherited by
 
  String primitives and `String` objects also give different results when using `eval()`.
  Primitives passed to `eval` are treated as source code;
+ `String` objects are treated as all other objects are, by returning the object
+ 
  
  
 #### Template Literals


### PR DESCRIPTION
UPDATED `Fundamental_of_JS.md` #10

Edited `#### Distinction between String Primitives and 'String' Objects`
in `### String` in `## Standard built-in objects`
+- Added description